### PR TITLE
pc - add instructions about manual grading

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@
 ruby "2.7.7"
 source "https://rubygems.org"
 gem "jekyll"
-gem "just-the-docs", "0.3.3"
+gem "just-the-docs", "0.4.1"
 #gem "jekyll-remote-theme"
 #gem "jekyll-seo-tag"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,8 @@ GEM
     eventmachine (1.2.7)
     ffi (1.15.5)
     forwardable-extended (2.6.0)
-    google-protobuf (3.22.0-x86_64-darwin)
-    google-protobuf (3.22.0-x86_64-linux)
+    google-protobuf (3.22.1-x86_64-darwin)
+    google-protobuf (3.22.1-x86_64-linux)
     http_parser.rb (0.8.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -38,10 +38,10 @@ GEM
       jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    just-the-docs (0.3.3)
+    just-the-docs (0.4.1)
       jekyll (>= 3.8.5)
-      jekyll-seo-tag (~> 2.0)
-      rake (>= 12.3.1, < 13.1.0)
+      jekyll-seo-tag (>= 2.0)
+      rake (>= 12.3.1)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -77,7 +77,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll
-  just-the-docs (= 0.3.3)
+  just-the-docs (= 0.4.1)
 
 RUBY VERSION
    ruby 2.7.7p221

--- a/_config.yml
+++ b/_config.yml
@@ -135,3 +135,20 @@ compress_html:
 
 plugins:
   - jekyll-seo-tag
+
+callouts_level: quiet # or loud
+callouts:
+  highlight:
+    color: yellow
+  important:
+    title: Important
+    color: blue
+  new:
+    title: New
+    color: green
+  note:
+    title: Note
+    color: purple
+  warning:
+    title: Warning
+    color: red

--- a/index.md
+++ b/index.md
@@ -16,6 +16,10 @@ seo:
 
 The links on the menu describe the steps towards completion of the final project.
 
+# What's New
+
+* 03/09: Check out the [clarification of manual grading criteria](/w23-project/step01#manual-grading) in Step 01
+
 # Due Dates
 
 All submissions are through Gradescope

--- a/step01.md
+++ b/step01.md
@@ -32,7 +32,7 @@ This project is supposed to be your **own individual work**. This project is ope
 
 We will run an automatic similarity check, which is not easily fooled by the variable / whitespace changes or other modifications.
 
-## Using advanced Python concepts
+## Using advanced Python concepts <a name="using-advanced-concepts"></a>
 
 You **MAY NOT USE**  material or techniques that we haven't covered in this course, either in the zyBook or in lecture, without *express advance permission* from the course staff.   If you do, you are subject to a grade of **FAIL** for the project.
 
@@ -259,12 +259,45 @@ Please plan accordingly to make sure that travel, Internet or electricity outage
 
 Your project will be automatically graded on Gradescope for the presence and naming of required files, functions, inclusion of docstrings, correct return values, etc. The autograder score will be the majority of the project grade.
 
-If there are no syntax errors, we will manually grade the final project checking the correct code style, use of comments, and use of asserts in your test file.
+If there are no syntax errors, we will manually grade the final project checking the correct code style, use of comments, and use of asserts in your test file (more on that below).
 
 If your project fails due to syntax errors, we will not manually grade it, automatically assigning it a 0 for the manual score. 
 
 ⚠️ Test your code for syntax errors before making a final submission!
 
+<blockquote class="new" markdown="block">
+
+# Manual Grading <a name="manual-grading"></a> 
+
+As you write your code, be mindful of the fact that there is also a manual
+component to the project grading.  
+
+Here are some of the things the manual check will be looking for:
+
+1. Did the solution use imports other than `import csv` and `import os`?
+2. Did the solution use Python features not covered in the course (e.g. lambda functions, map/reduce, etc.) without advance permission (as described in the section [Using Advanced Python Concepts](#using-advanced-concepts))?
+3. Are variable name choices reasonable?  Single letter variable names should be avoided except as the index of a for loop (e.g. `i` and `j`). As was explained in zyBooks and in class, one should meaningful variable names for better code readability and clarity.
+4. Are the docstrings actually meaningful and clear, or are they just placeholders, as in the example shown here:
+
+   ```python
+   def add_em(param1, param2):
+      """
+      this is a placeholder docstring, worse than useless
+      """
+      return param1 + param2
+
+   ```
+
+   Specifically, docstrings for functions of the form `is_valid_x` such as `is_valid_name`, `is_valid_calories` etc. should describe:
+
+   * input parameter and its type
+	* return value
+
+5. Did the student hard code specific return values for specific test cases shown by the autograder (that's bad), or did they  actually make a good faith effort to understand the problem and provide a solution (that's good)?
+
+If you have questions about this, please ask on Piazza.
+
+</blockquote>
 
 -----
 


### PR DESCRIPTION
In this PR, we add these instructions for manual grading into Step 01:

<img width="854" alt="image" src="https://user-images.githubusercontent.com/1119017/224113756-0e16f416-7bea-4c47-9208-8b9160896992.png">

<img width="860" alt="image" src="https://user-images.githubusercontent.com/1119017/224113860-faa7820b-25f5-4c8e-8429-4d1a1ed831dc.png">

We also add this to the home page:

<img width="692" alt="image" src="https://user-images.githubusercontent.com/1119017/224114047-a9927c6b-e264-4bcc-8e72-a44fa59bcd2a.png">

Finally: we also bump the version of just-the-docs to v0.4.1 to add support for [callouts](https://just-the-docs.github.io/just-the-docs/docs/ui-components/callouts/), and add a few callout definitions into `_config.yml`